### PR TITLE
Update hp_BH1750.cpp

### DIFF
--- a/src/hp_BH1750.cpp
+++ b/src/hp_BH1750.cpp
@@ -422,7 +422,6 @@ unsigned int hp_BH1750::readValue()
 {
   byte buff[2];
   int i;
-  _wire->beginTransmission(_address);
   unsigned int req = _wire->requestFrom((int)_address, (int)2); // request two bytes
   if (req == 0)
   {


### PR DESCRIPTION
This line is not used on reading data (only for writing!) - removing this lets it work on RP2040 and ESP32-S2 without affecting functionality