### PR TITLE
compile without warnings

### DIFF
--- a/examples/BareMinimum/BareMinimum.ino
+++ b/examples/BareMinimum/BareMinimum.ino
@@ -9,6 +9,10 @@ void setup()
   Serial.begin(9600);
   bool avail = BH1750.begin(BH1750_TO_GROUND);// init the sensor with address pin connetcted to ground
                                               // result (bool) wil be be "false" if no sensor found
+  if (!avail) {
+    Serial.println("No BH1750 sensor found!");
+    while (true) {};                                        
+  }
 }
 
 void loop()

--- a/examples/Non_blocking/Non_blocking.ino
+++ b/examples/Non_blocking/Non_blocking.ino
@@ -10,8 +10,14 @@ void setup()
  
   bool avail = BH1750.begin(BH1750_TO_GROUND);   // will be false no sensor found
                                                  // use BH1750_TO_GROUND or BH1750_TO_VCC depending how you wired the address pin of the sensor.
+  if (!avail) {
+    Serial.println("No BH1750 sensor found!");
+    while (true) {};                                        
+  }
   
   // BH1750.calibrateTiming();  //uncomment this line if you want to speed up your sensor
+  Serial.printf("conversion time: %dms\n", BH1750.getMtregTime());
+  
   BH1750.start();               //start the first measurement in setup
 }
 

--- a/examples/SampleRate/SampleRate.ino
+++ b/examples/SampleRate/SampleRate.ino
@@ -26,7 +26,7 @@ void loop()
   //  put your main code here, to run repeatedly:
   Serial.println("***********");
   unsigned int t = millis() + 1000;
-  int c = 0;
+  unsigned int c = 0;
   while (millis() <= t)
   {
     sens.start(BH1750_QUALITY_LOW, 1); //will be adjusted to lowest allowed MTreg (default = 31)
@@ -36,18 +36,18 @@ void loop()
     }
     else
     {
-      unsigned int dummy = sens.getRaw();
+      sens.getRaw();
     }
     yield(); //  feed the watchdog of ESP6682
     c++;
   }
-  int readVal = c;
+  unsigned int readVal = c;
   if (readVal > MAX_VAL)
     c = MAX_VAL;
   // Serial.print(c);
   // Serial.print(char(9));
   // Serial.println(sens.getRaw());
-  for (int i = 0; i < c; i++)
+  for (unsigned int i = 0; i < c; i++)
   {
     //Serial.print(i);
     Serial.print(val[i]);
@@ -59,5 +59,6 @@ void loop()
   Serial.println("");
   Serial.print(readVal);
   Serial.println(" Samples per second");
+  Serial.println("");
   delay(1000);
 }

--- a/examples/TestSuite/TestSuite.ino
+++ b/examples/TestSuite/TestSuite.ino
@@ -25,11 +25,11 @@ void printHelp()
   Serial.println(F("Enter \"m\" followed by a number between 31 to 254, to change the quality"));
   Serial.println(F("Enter \"c\" to calibrate the sensor timing"));
   Serial.println(F("Enter \"i\" to init the sensor to factory timing"));
-  Serial.println(F("Enter \"q\", followed by a number between 1 to 3, to change the quality"));
+  Serial.println(F("Enter \"q\" followed by a number between 1 to 3, to change the quality"));
   Serial.println(F("Enter \"a\" to toggle between fixed MTreg and AUTORANGE"));
   Serial.println(F("Enter \"s\" to toggle between all informations or only for Lux. Try serial plotter!"));
   Serial.println(F("Enter \"o\" with a positive or negative number to change the time offset"));
-  Serial.println(F("Enter \"t\"followed by a number to change the timeout in ms."));
+  Serial.println(F("Enter \"t\" followed by a number to change the timeout in ms."));
   Serial.println(F("Enter \"f\" to toggle between forced readings or only waiting for the estimated conversion time"));
   Serial.println(F("Enter \"r\" to toggle between forced preShots in autorange mode"));
   Serial.print(F("*********************************************************************************************"));
@@ -54,6 +54,7 @@ void flushQueue(unsigned int timeout)
     busyDelay(timeout);
   }
 }
+
 void waitKeyPress()
 {
   Serial.println(F(""));
@@ -64,6 +65,7 @@ void waitKeyPress()
   }
   flushQueue(3);
 }
+
 String getQual()
 {
   BH1750Quality q = BH1750.getQuality();
@@ -76,6 +78,7 @@ String getQual()
       return "High ";
       break;
     case BH1750_QUALITY_HIGH2:
+    default:
       return "High2";
       break;
   }
@@ -92,6 +95,7 @@ void printCalib()
   Serial.println(buf);
   Serial.println("");
 }
+
 void setup()
 {
   Serial.begin(9600);

--- a/src/hp_BH1750.cpp
+++ b/src/hp_BH1750.cpp
@@ -409,7 +409,7 @@ unsigned int hp_BH1750::getRaw()
   return _value;
 }
 
-bool hp_BH1750::processed()
+bool hp_BH1750::processed() const
 {
   return _processed;
 }
@@ -515,14 +515,14 @@ float hp_BH1750::getLux()
 //********************************************************************************************
 // Calculate a given digital value (from getRaw()) to Lux
 
-float hp_BH1750::calcLux(int raw)
+float hp_BH1750::calcLux(int raw) const
 {
   return (float)raw / luxFactor * _qualFak * 69 / _mtreg;
 }
 
 // Calculate a given digital value (from getRaw()) to Lux
 
-float hp_BH1750::calcLux(int raw, BH1750Quality quality, int mtreg)
+float hp_BH1750::calcLux(int raw, BH1750Quality quality, int mtreg) const
 {
   float qualFak = 0.5;
   if (quality != BH1750_QUALITY_HIGH2)
@@ -532,7 +532,7 @@ float hp_BH1750::calcLux(int raw, BH1750Quality quality, int mtreg)
 
 // Check if last value is over 65535 raw data
 
-bool hp_BH1750::saturated()
+bool hp_BH1750::saturated() const
 {
   return (_value == BH1750_SATURATED);
 }

--- a/src/hp_BH1750.h
+++ b/src/hp_BH1750.h
@@ -77,24 +77,24 @@ public:
   float calcLux(int raw, BH1750Quality quality, int mtreg);
   float luxFactor = 1.2;
   void setTiming(BH1750Timing timing);
-  BH1750Timing getTiming();
+  BH1750Timing getTiming() const;
 
-  BH1750Quality getQuality();
+  BH1750Quality getQuality() const;
 
   void setTimeout(int timeout);
 
   void setTimeOffset(int offset);
-  int getTimeOffset();
-  unsigned int getTimeout();
-  byte getMtreg();
+  int getTimeOffset() const;
+  unsigned int getTimeout() const;
+  byte getMtreg() const;
   byte convertTimeToMtreg(unsigned int time, BH1750Quality quality);
-  byte getPercent();
+  byte getPercent() const;
   unsigned int getRaw();
-  unsigned int getReads();
-  unsigned int getTime();
-  unsigned int getMtregTime();
-  unsigned int getMtregTime(byte mtreg);
-  unsigned int getMtregTime(byte mtreg, BH1750Quality quality);
+  unsigned int getReads() const;
+  unsigned int getTime() const;
+  unsigned int getMtregTime() const;
+  unsigned int getMtregTime(byte mtreg) const;
+  unsigned int getMtregTime(byte mtreg, BH1750Quality quality) const;
 
   bool adjustSettings(byte percent = 50, bool forcePreShot = false);
   void calcSettings(unsigned int value, BH1750Quality &qual, byte &mtreg, byte percent);

--- a/src/hp_BH1750.h
+++ b/src/hp_BH1750.h
@@ -70,11 +70,11 @@ public:
   bool start();
   bool start(BH1750Quality quality, byte mtreg);
   bool hasValue(bool forceSensor = false);
-  bool processed();
-  bool saturated();
+  bool processed() const;
+  bool saturated() const;
   float getLux();
-  float calcLux(int raw);
-  float calcLux(int raw, BH1750Quality quality, int mtreg);
+  float calcLux(int raw) const;
+  float calcLux(int raw, BH1750Quality quality, int mtreg) const;
   float luxFactor = 1.2;
   void setTiming(BH1750Timing timing);
   BH1750Timing getTiming() const;


### PR DESCRIPTION
Hi,
nice library with this calibrateTiming() feature!
I fixed a few things, mainly to make it compile without warnings:
- empty lines between functions
- getters are const
- added default target to switches
- removed unused variables
- fixed readValue(): requestFrom() does not need endTransmission() (this is only for sending data). requestFrom retturns number of read bytes, it will never be larger than the requested number, so no while loop need for reading the data.

I do not know why the examples are shown completely in the diff, maybe the linebreak characters changed. I only added the check for availability.