### PR TITLE
fixed calcSettings

### DIFF
--- a/src/hp_BH1750.cpp
+++ b/src/hp_BH1750.cpp
@@ -577,16 +577,16 @@ void hp_BH1750::calcSettings(unsigned int value, BH1750Quality &qual, byte &mtre
   if (percent > 100)
     percent = 100;
   _percent = percent;
-  unsigned long highBound = value / (float)percent * 100;
+  if (value==0)
+    value=1;
+  float highBound = value / (float)percent * 100;
   unsigned long newMtreg = (float)BH1750_SATURATED / highBound * mtreg + .5;
-  if (value==0) value=1;
   switch (qual)
   {
     case BH1750_QUALITY_HIGH:
       if (newMtreg >= BH1750_MTREG_LOW * 2)
-      //if (newMtreg > BH1750_MTREG_LOW * 2)
       {
-        newMtreg = newMtreg / 2;
+        newMtreg /= 2;
         qual = BH1750_QUALITY_HIGH2;
       }
       break;
@@ -594,7 +594,7 @@ void hp_BH1750::calcSettings(unsigned int value, BH1750Quality &qual, byte &mtre
       if (newMtreg < BH1750_MTREG_LOW)
       {
         qual = BH1750_QUALITY_HIGH;
-        newMtreg = newMtreg * 2;
+        newMtreg *= 2;
       }
     case BH1750_QUALITY_LOW:
     default: ;

--- a/src/hp_BH1750.cpp
+++ b/src/hp_BH1750.cpp
@@ -553,7 +553,7 @@ bool hp_BH1750::saturated() const
 // switch between this values when requiered
 // If you use the fast, but low qualtiy BH1750_QUALITY_LOW = 0x23, the function will not change this quality.
 
-bool hp_BH1750::adjustSettings(byte percent, bool forcePreShot)
+bool hp_BH1750::adjustSettings(float percent, bool forcePreShot)
 {
   if (_value == BH1750_SATURATED || forcePreShot == true) // If last result is saturated, perfom a measurement at low sensitivity
   {
@@ -572,14 +572,14 @@ bool hp_BH1750::adjustSettings(byte percent, bool forcePreShot)
 // You have to declare the variables BH1750Quality and mtreg bevore calling this function
 // After calling this function this variables contain the appropiate values
 
-void hp_BH1750::calcSettings(unsigned int value, BH1750Quality &qual, byte &mtreg, byte percent)
+void hp_BH1750::calcSettings(unsigned int value, BH1750Quality &qual, byte &mtreg, float percent)
 {
-  if (percent > 100)
-    percent = 100;
+  if (percent > 100.0)
+    percent = 100.0;
   _percent = percent;
   if (value==0)
     value=1;
-  float highBound = value / (float)percent * 100;
+  float highBound = value / percent * 100.0;
   unsigned long newMtreg = (float)BH1750_SATURATED / highBound * mtreg + .5;
   switch (qual)
   {
@@ -604,6 +604,6 @@ void hp_BH1750::calcSettings(unsigned int value, BH1750Quality &qual, byte &mtre
   mtreg = newMtreg;
 }
 
-byte hp_BH1750::getPercent() const {
+float hp_BH1750::getPercent() const {
   return _percent;
 }

--- a/src/hp_BH1750.h
+++ b/src/hp_BH1750.h
@@ -88,7 +88,7 @@ public:
   unsigned int getTimeout() const;
   byte getMtreg() const;
   byte convertTimeToMtreg(unsigned int time, BH1750Quality quality);
-  byte getPercent() const;
+  float getPercent() const;
   unsigned int getRaw();
   unsigned int getReads() const;
   unsigned int getTime() const;
@@ -96,8 +96,8 @@ public:
   unsigned int getMtregTime(byte mtreg) const;
   unsigned int getMtregTime(byte mtreg, BH1750Quality quality) const;
 
-  bool adjustSettings(byte percent = 50, bool forcePreShot = false);
-  void calcSettings(unsigned int value, BH1750Quality &qual, byte &mtreg, byte percent);
+  bool adjustSettings(float percent = 50.0, bool forcePreShot = false);
+  void calcSettings(unsigned int value, BH1750Quality &qual, byte &mtreg, float percent);
 
 private:
   TwoWire *_wire;


### PR DESCRIPTION
Some little changes in `calcSettings()`:
- make sure value is not zero *before* you use it.
- `highBound` is used as float so it should be a float.
- use /= and */ operands.